### PR TITLE
add current puppet-agent's ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ script: "bundle exec rspec --color --format documentation"
 notifications:
   email: false
 rvm:
+  - 2.1.6
   - 2.0.0
   - 1.9.3
   - 1.8.7


### PR DESCRIPTION
the puppet-agent AIO package uses ruby 2.1.6
we should test with that too!